### PR TITLE
Post 2.1.6 Fixes

### DIFF
--- a/AncientReligions/common/event_modifiers/druidic_modifiers.txt
+++ b/AncientReligions/common/event_modifiers/druidic_modifiers.txt
@@ -77,7 +77,7 @@ promised_victory = {
 
 promised_riches = {
 	local_tax_modifier = 0.04
-	city_opinion = 5
+	town_opinion = 5
 	tech_growth_modifier_economy = 0.04
 	icon = 10
 }
@@ -91,8 +91,8 @@ held_divination_timer = {
 #####################################################################
 
 favored_warriors = {
-	feudal_opinion = 10
-	city_opinion = -10
+	castle_opinion = 10
+	town_opinion = -10
 	monthly_character_prestige = 0.02
 	tech_growth_modifier_military = 0.03
 	icon = 13
@@ -100,7 +100,7 @@ favored_warriors = {
 
 favored_druids = {
 	church_opinion = 10
-	city_opinion = -10
+	town_opinion = -10
 	monthly_character_prestige = 0.02
 	monthly_character_piety = 0.1
 	tech_growth_modifier_culture = 0.03
@@ -109,8 +109,8 @@ favored_druids = {
 
 favored_merchants = {
 	monthly_character_prestige = 0.02
-	city_opinion = 10
-	feudal_opinion = -10
+	town_opinion = 10
+	castle_opinion = -10
 	church_opinion = -10
 	tech_growth_modifier_culture = 0.02
 	tech_growth_modifier_military = 0.02
@@ -136,8 +136,8 @@ favored_fianna = {
 
 favored_crown = {
 	monthly_character_prestige = 0.05
-	city_opinion = -10
-	feudal_opinion = -10
+	town_opinion = -10
+	castle_opinion = -10
 	church_opinion = -10
 	tech_growth_modifier_culture = 0.05
 	tech_growth_modifier_military = 0.05

--- a/AncientReligions/common/landed_titles/ACR_new_titles.txt
+++ b/AncientReligions/common/landed_titles/ACR_new_titles.txt
@@ -34,7 +34,7 @@ d_wolftails = {
 	
 	strength_growth_per_century = 1.0
 
-	modifier = d_wolftails_modifier
+	mercenary_type = wolftails_composition
 }
 
 # HOLY ORDERS
@@ -64,7 +64,7 @@ d_red_dragons = {
 	# Cannot be held as a secondary title
 	primary = yes
 
-	modifier = d_red_dragons_modifier
+	mercenary_type = red_dragons_composition
 }
 
 d_fianna = {
@@ -92,7 +92,7 @@ d_fianna = {
 	# Cannot be held as a secondary title
 	primary = yes
 
-	modifier = d_fianna_modifier
+	mercenary_type = fianna_composition
 }
 
 # Pagan heads of religion

--- a/AncientReligions/common/mercenaries/druidic_mercenaries.txt
+++ b/AncientReligions/common/mercenaries/druidic_mercenaries.txt
@@ -1,0 +1,25 @@
+# Define mercenary types here now instead of in the static_composition.txt file
+# Also remember to tell the landed title to use this mercenary type instead.
+# Several titles can refer to the same type as well now.
+
+wolftails_composition = {
+	levy_size = 3.0
+	archers = 300
+	pikemen = 150
+	heavy_infantry = 150
+	light_cavalry = 150
+}
+
+red_dragons_composition = {
+	levy_size = 6
+	knights = 200
+	archers = 250
+	heavy_infantry = 250
+}
+
+fianna_composition = {
+	levy_size = 6
+	heavy_infantry = 700
+	light_infantry = 300
+	archers = 500
+}

--- a/AncientReligions/interface/generalstuff.gfx
+++ b/AncientReligions/interface/generalstuff.gfx
@@ -658,12 +658,12 @@ spriteTypes = {
 	spriteType = {
 		name = "GFX_religion_icon_strip"
 		texturefile = "gfx\\interface\\religion_icon_strip.dds"
-		noOfFrames = 60
+		noOfFrames = 62
 	}
 	spriteType = {
 		name = "GFX_religion_icon_strip_small"
 		texturefile = "gfx\\interface\\religion_icon_strip_small.dds"
-		noOfFrames = 60
+		noOfFrames = 62
 	}
 	spriteType = {
 		name = "GFX_commandmodifier_icon"

--- a/AncientReligions/localisation/Aonach Tailteann Chain.csv
+++ b/AncientReligions/localisation/Aonach Tailteann Chain.csv
@@ -37,7 +37,7 @@ EVTOPTDancrel.1199;I will treat everyone equaly;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 EVTOPTEancrel.1199;I will favor the crown;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 EVTOPTFancrel.1199;I will favor the fianna;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 EVTOPTGancrel.1199;I will favor the birds!;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
-give_laws_ollam;The Ollamh distribues the new laws to your vassals;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+give_laws_ollam;The Ollamh distribues the new laws to your vassals\n;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 favored_warriors;Favors the Warrior caste;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 favored_druids;Favors the Druidic caste;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 favored_merchants;Favors the Merchant caste;FRENCH;GERMAN;SPANISH;;;;;;;;;;x

--- a/AncientReligions/localisation/Druidic.csv
+++ b/AncientReligions/localisation/Druidic.csv
@@ -59,12 +59,16 @@ city_emperor_female_druidic_reformed;Lady;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 city_empire_of_druidic_reformed;Nation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 ;;;;;;;;;;
 temple_baron_druidic_reformed;Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_baron_female_druidic_reformed;Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_barony_of_druidic_reformed;Sacred Grove of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_count_druidic_reformed;Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_count_female_druidic_reformed;Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_county_of_druidic_reformed;Temple of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_duke_druidic_reformed;Head Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_duke_female_druidic_reformed;Head Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_duchy_of_druidic_reformed;Tribe of;Tribu de;Stamm der;;Tribu de;;;;;;;;;x
 temple_king_druidic_reformed;Archdruid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_king_female_druidic_reformed;Archdruidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_kingdom_of_druidic_reformed;Federation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_emperor_druidic_reformed;Myrdynn;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_empire_of_druidic_reformed;Nation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
@@ -105,12 +109,16 @@ city_emperor_female_druidic;Lady;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 city_empire_of_druidic;Nation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 ;;;;;;;;;;
 temple_baron_druidic;Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_baron_female_druidic;Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_barony_of_druidic;Sacred Grove of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_count_druidic;Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_count_female_druidic;Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_county_of_druidic;Temple of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_duke_druidic;Head Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_duke_female_druidic;Head Druidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_duchy_of_druidic;Tribe of;Tribu de;Stamm der;;Tribu de;;;;;;;;;x
 temple_king_druidic;Archdruid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+temple_king_female_druidic;Archdruidess;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_kingdom_of_druidic;Federation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_emperor_druidic;Myrdynn;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 temple_empire_of_druidic;Nation of;FRENCH;GERMAN;SPANISH;;;;;;;;;;x


### PR DESCRIPTION
- Fix 0 troops for druidic mercenaries and holy orders: uses mercenaries composition in separate file, instead of static modifier
- Fix number of frames of religion icon (60 -> 62)
- Fix castle/town opinion modifier names (NONE showing up in Aonach Tailteann events)
- Add newline after custom_tooltip text to prevent wrapping with 1st condition
- Add localization for female druidic temple holder (Druidess instead of generic title Priestess)
