### PR TITLE
Celtic suggestions

### DIFF
--- a/AncientReligions/common/job_titles.txt
+++ b/AncientReligions/common/job_titles.txt
@@ -33,20 +33,21 @@ job_chancellor = {
 			has_character_flag = special_chancellor
 		}
 		
-		or = {
+		OR = {
 			liege = { 
-				not = { 
+				NOT = { 
 					religion = druidic 
 					religion = druidic_reformed
 				}
 			}
-		   and = {
-				or = { 
+		   AND = {
+				OR = { 
 					religion = druidic 
 					religion = druidic_reformed 
 				}
-				or = { 
+				OR = { 
 					trait = druid
+					trait = bad_druid
 					trait = poet
 				}
 			}
@@ -276,7 +277,10 @@ job_spiritual = {
 					religion = druidic 
 					religion = druidic_reformed 
 				}
-				trait = druid
+				OR = {
+					trait = druid
+					trait = bad_druid
+				}
 			}
 		}
 	}

--- a/AncientReligions/common/landed_titles/ACR_new_titles.txt
+++ b/AncientReligions/common/landed_titles/ACR_new_titles.txt
@@ -186,7 +186,10 @@ d_druidic_reformed = {
 		religion = druidic_reformed
 		num_of_holy_sites = 1
 		piety = 1000
-		trait = druid
+		OR = {
+			trait = druid
+			trait = bad_druid
+		}
 	}
 	
 	# Controls a religion

--- a/AncientReligions/common/minor_titles/druidic_minor_titles.txt
+++ b/AncientReligions/common/minor_titles/druidic_minor_titles.txt
@@ -15,7 +15,10 @@ title_court_druid = {
 	allow = {
 		is_adult = yes
 		is_ruler = no
-		trait = druid
+		OR = {
+			trait = druid
+			trait = bad_druid
+		}
 		OR = {
 			religion = druidic
 			religion = druidic_reformed
@@ -88,7 +91,7 @@ title_royal_champion = {
 					primary_title = {
 						tier = duke			# or an independent duke
 					}
-					is_independent = yes
+					independent = yes
 				}
 			}
 			OR = {
@@ -96,17 +99,14 @@ title_royal_champion = {
 				religion = druidic_reformed
 			}
 		}
-		AND = {
-			OR = {
-				religion = druidic
-				religion = druidic_reformed
-
-			}
-			OR = {
-				trait = head1
-				trait = head2
-				trait = fian
-			}
+		OR = {
+			religion = druidic
+			religion = druidic_reformed
+		}
+		OR = {
+			trait = head1
+			trait = head2
+			trait = fian
 		}
 		NOT = { has_minor_title = title_vates }
 		NOT = { has_minor_title = title_court_druid }

--- a/AncientReligions/common/on_actions/ACR_on_actions.txt
+++ b/AncientReligions/common/on_actions/ACR_on_actions.txt
@@ -1,5 +1,234 @@
 # ACR impacted on_actions: vanilla events need to be kept, as it does a full override of events & random_events lists
 
+#character
+on_yearly_pulse = {
+	events = {
+		ancrel.0153 # Liege doesn't have a Druid
+	}
+	random_events = {
+		
+		# Feudal Life Events
+		100 = 4000
+		100 = 4005
+		100 = 4010
+		100 = 4015
+		100 = 4020
+		100 = 4035
+		100 = 4036
+		100 = 4040
+		100 = 4041
+		100 = 4045
+		100 = 4050
+		100 = 4055
+		100 = 4060
+		100 = 4085
+		100 = 4110
+		100 = 4115
+		100 = 4120
+		100 = 4125
+		100 = 4130
+		100 = 4135
+		100 = 4145
+		100 = 4150
+		100 = 4155
+		100 = 4175
+		
+		# Married Life Events
+		100 = 30000
+		100 = 30001
+		100 = 30004
+		100 = 30020
+		100 = 30021
+		100 = 30025
+		100 = 30030
+		100 = 30040
+		100 = 30045
+		100 = 30050
+		100 = 30051
+		100 = 30052
+		100 = 30055
+		100 = 30056
+		100 = 30057
+		100 = 30058
+		100 = 30059
+		100 = 30060
+		100 = 30063
+		100 = 30066
+		100 = 30069
+		100 = 30072
+		100 = 30075
+		100 = 30085
+		100 = 30100
+		100 = 30105
+		100 = 30110
+		
+		#Lovers Events
+		100 = 64000
+		100 = 64005
+		100 = 64006
+		100 = 64010
+		100 = 64015
+		100 = 64025
+		100 = 64030
+		100 = 64035
+		100 = 64040
+		
+		#Job Flavour Events
+		100 = 75010
+		100 = 75020
+		100 = 75030
+		100 = 75040
+		100 = 75050
+		100 = 75060
+		100 = 75065
+		100 = 75070
+		100 = 75075
+		100 = 75080
+		100 = 75085
+		100 = 75090
+		100 = 75095
+		100 = 75105
+		100 = 75110
+		100 = 75120
+
+		#Dynasty requests
+		250 = 66000
+		250 = 66050
+		250 = 66100
+		
+		#Hedge Knights Events
+		100 = 71000 
+		100 = 71006 
+		
+		#Rumours Events
+		10 = 69000
+		10 = 69003 
+		10 = 69010 
+		10 = 69014 
+		10 = 69020 
+		10 = 69023 
+		10 = 69030 
+		10 = 69037 
+		10 = 69040 
+		10 = 69043 
+		10 = 69050 
+		10 = 69052 
+		10 = 69054 
+		10 = 69056 
+		10 = 69058  
+		10 = 69060  
+		10 = 69063  
+		10 = 69070
+		10 = 69073
+		10 = 69100
+		10 = 69095
+		
+		#Court Events
+		100 = 73000
+		100 = 73001
+		100 = 73002
+		100 = 73003
+		100 = 73004
+		100 = 73005
+		100 = 73006
+		100 = 73007
+		100 = 73008
+		100 = 73009
+		100 = 73010
+		
+		#Religious Events
+		100 = 39230
+		
+		#Bastard Events
+		100 = 76000
+		100 = 76005
+		100 = 76010
+		100 = 76015
+		100 = 76020
+		100 = 76025
+		100 = 76030
+		100 = 76035
+		100 = 76040
+		
+		#Ward Events
+		100 = 78000
+		100 = 78005
+		100 = 78010
+		100 = 78015
+		100 = 78020
+		100 = 78025
+		100 = 78030
+		
+		#Various Events
+		100 = TOG.3403
+		100 = TOG.3401
+		100 = TOG.3402
+		
+		# Reincarnation: Memories of the previous life
+		1000 = RoI.10020
+		1000 = RoI.10021
+		1000 = RoI.10022
+		
+		# Indian guru events
+		100 = RoI.3100
+		100 = RoI.3101
+		100 = RoI.3102
+		100 = RoI.3103
+		100 = RoI.3104
+		100 = RoI.3105
+		100 = RoI.3106
+		100 = RoI.3107
+		100 = RoI.3108
+		100 = RoI.3109
+		100 = RoI.3110
+		100 = RoI.3111
+		100 = RoI.3112
+		100 = RoI.3113
+		100 = RoI.3114
+		500 = RoI.3200
+		500 = RoI.3300
+		100 = RoI.3400
+		
+		# Indian ascetics and yogis
+		20 = RoI.203
+		20 = RoI.206
+		20 = RoI.209
+		20 = RoI.193
+		
+		# Indian story events
+		20 = RoI.215
+		20 = RoI.20147
+		20 = RoI.20164
+		
+		# Indian minor events
+		100 = RoI.157
+		100 = RoI.158
+		100 = RoI.163
+		100 = RoI.180
+		100 = RoI.190
+		50 = RoI.401
+		100 = RoI.403
+		100 = RoI.410
+		100 = RoI.411
+		200 = RoI.412
+		500 = RoI.500
+		
+		# Indian low religious authority events
+		50 = RoI.3500
+		50 = RoI.3506
+		50 = RoI.3510
+		50 = RoI.3516
+		10 = RoI.3520
+		50 = RoI.3530
+		50 = RoI.3536
+		
+		# Religious tolerance events
+		100 = RoI.400
+		
+		5000 = 0 # Chance of no yearly event
+	}
+}
+
 on_death = {
 	events = {
 		650
@@ -10,8 +239,8 @@ on_death = {
 		SoA.5306
 		705
 	
-		ancrel.1194
-		ancrel.2123
+		ancrel.1194 # Ruler has died, the Aonach is over
+		ancrel.2123 # Cleanup when a Vestalis dies
 		45340 # Thirteen treasures inheritance
 	}
 	
@@ -45,6 +274,8 @@ on_birth = {
 	random_events = {
 		200 = 0
 		1 = RoI.10000 # Reincarnation?
+		
+		1 = ancrel.0270 # Reincarnation (celtic) ?
 	}
 }
 
@@ -53,6 +284,90 @@ on_adulthood = {
 		SoA.3020 # Demon child's true nature asserts itself
 		
 		ancrel.0241   # Changeling child's true nature asserts itself
+	}
+}
+
+
+# For characters 2 to 16 years old
+on_yearly_childhood_pulse = {
+	random_events = {
+		# Childhood Personality Events
+		
+		#Age 6-16, aiming to get at least 4 traits before adult.
+		100 = 1500
+		100 = 1510
+		100 = 1520
+		100 = 1530
+		100 = 1540
+		100 = 1550
+		100 = 1560
+		100 = 1570
+		100 = 1580
+		100 = 1590
+		100 = 1600
+		100 = 1610
+		100 = 1620
+		100 = 1630
+		100 = 1640
+		100 = 1650
+		100 = 1660
+		100 = 1670
+		100 = 1680
+		100 = 1690
+		100 = 1700
+		100 = 1710
+		100 = 1720
+		100 = 1730
+		100 = 1965
+		100 = 1632
+		100 = 1732
+		5000 = RoI.10010 # Acknowledged reincarnated child acquires trait from previous personality
+		
+		5000 = ancrel.0272 # Acknowledged reincarnated child acquires trait from previous personality
+		
+		#Toddler flavour events (age 2-5), not very common, but some will get them.
+		10 = 1900 
+		10 = 1901
+		10 = 1902
+		10 = 1903
+		10 = 1904
+		
+		#Young children flavour events, (age 6-10), not very common, but some will get then..
+		20 = 1905
+		20 = 1906
+		20 = 1907
+		20 = 1908
+		20 = 1909
+		20 = 1910
+		20 = 1911
+		20 = 1912
+		
+		#Youngsters flavour events (age 11-15), not very common, but some will get then..
+		50 = 1913
+		50 = 1914
+		50 = 1915
+		50 = 1916
+		50 = 1917
+		50 = 1918
+		50 = 1919
+		50 = 1920
+		50 = 1921
+		50 = 1922
+		50 = 1923
+		50 = 1924
+		50 = 1925
+		50 = 1926
+		50 = 1927
+		50 = 1928
+		50 = 1929
+		50 = 1930
+		50 = 1931
+		50 = 1932
+		50 = 1933
+		50 = 1934
+		50 = 1935
+		
+		1500 = 0
 	}
 }
 

--- a/AncientReligions/common/traits/druidic_traits.txt
+++ b/AncientReligions/common/traits/druidic_traits.txt
@@ -1,4 +1,5 @@
 head1 = {
+	
 	potential = {
 		religion_group = pagan_group
 	}
@@ -14,6 +15,7 @@ head1 = {
 }
 
 head2 = {
+	
 	potential = {
 		religion_group = pagan_group
 	}
@@ -33,18 +35,50 @@ head2 = {
 }
 
 druid = {
+	
 	potential = {
 		religion_group = pagan_group
 	}
+	opposites =  {
+		bad_druid
+	}
+	
+	religious = no # Cleared manually on religious conversion, to avoid losing it on reformation
+	
 	monthly_character_piety = 0.5
 	learning = 3
 	diplomacy = 2
+	
 	customizer = no
 	
 	cannot_inherit = yes
 }
 
-fian = {
+bad_druid = {
+
+	potential = {
+		religion_group = pagan_group
+	}
+	opposites =  {
+		druid
+	}
+	
+	religious = no # Cleared manually on religious conversion, to avoid losing it on reformation
+	
+	opposite_opinion = -10
+	church_opinion = -20
+	same_opinion_if_same_religion = 50
+	
+	monthly_character_piety = -1
+
+	customizer = no
+	random = no
+	
+	cannot_inherit = yes
+}
+
+fian = {	
+
 	potential = {
 		religion_group = pagan_group
 	}
@@ -67,6 +101,7 @@ fian = {
 }
 
 celtic_knight = {
+
 	potential = {
 		religion = druidic_reformed
 	}
@@ -94,6 +129,7 @@ celtic_knight = {
 }
 
 learning_druidic_arts = {
+	
 	potential = {
 		religion_group = pagan_group
 	}
@@ -112,6 +148,7 @@ learning_druidic_arts = {
 }
 
 changeling = {
+	
 	potential = {
 		religion_group = pagan_group
 	}

--- a/AncientReligions/decisions/druidic_decisions.txt
+++ b/AncientReligions/decisions/druidic_decisions.txt
@@ -282,11 +282,6 @@ decisions = {
 			NOT = { has_character_flag = inviting_druid_over }
 			primary_title = { higher_tier_than = BARON }
 			NOT = {
-				any_vassal = {
-					has_minor_title = title_court_druid
-				}
-			}
-			NOT = {
 				any_courtier = {
 					has_minor_title = title_court_druid
 				}
@@ -313,20 +308,12 @@ decisions = {
 			}
 			modifier = {
 				factor = 0.1
-				OR = {
-					any_vassal = {
-						has_minor_title = title_court_druid
-					}
-					any_courtier = {
-						has_minor_title = title_court_druid
-					}
+				any_courtier = {
+					has_minor_title = title_court_druid
 				}
 			}
 			modifier = {
 				factor = 0.1
-				any_vassal = {
-					trait = druid
-				}
 				any_courtier = {
 					trait = druid
 				}

--- a/AncientReligions/events/aonach_tailteann_events.txt
+++ b/AncientReligions/events/aonach_tailteann_events.txt
@@ -107,7 +107,7 @@ character_event = {
 	}
 }
 
-# Ruler has died, the Aonach is over
+#[on_death] Ruler has died, the Aonach is over
 character_event = {
 	id = ancrel.1194
 	title = TAILTEANNTITLE

--- a/AncientReligions/events/celtic_changelings.txt
+++ b/AncientReligions/events/celtic_changelings.txt
@@ -861,7 +861,7 @@ character_event = {
 	}
 }
 
-# Changeling child becomes and adult (Trait makes character more keen to go on adventures and harder to kill)
+#[on_adulthood] Changeling child becomes and adult (Trait makes character more keen to go on adventures and harder to kill)
 character_event = {
 	id = ancrel.0241
 	desc = EVTDESCancrel.0241

--- a/AncientReligions/events/celtic_flavor_events.txt
+++ b/AncientReligions/events/celtic_flavor_events.txt
@@ -453,8 +453,8 @@ character_event = {
 # Y Mab Darogan
 narrative_event = {
 	id = ancrel.0256
-	title = ancrel.0256.name
-	desc = EVTDESCancrel.0256
+	title = "EVTNAMEancrel.0256"
+	desc = "EVTDESCancrel.0256"
 	picture = GFX_event_y_mab_darogan
 	
 	only_rulers = yes

--- a/AncientReligions/events/celtic_headhunter_events.txt
+++ b/AncientReligions/events/celtic_headhunter_events.txt
@@ -11,7 +11,7 @@
 
 namespace = ancrel
 
-#Druidic character becomes reknowned headhunter
+#[on_combat_pulse] Druidic character becomes reknowned headhunter
 character_event = {
 	id = ancrel.0010
 	desc = EVTDESCancrel.0010
@@ -159,7 +159,7 @@ character_event = {
 	}
 }
 
-#Druidic character becomes legend
+#[on_combat_pulse] Druidic character becomes legend
 character_event = {
 	id = ancrel.0011
 	desc = EVTDESCancrel.0011

--- a/AncientReligions/events/celtic_reincarnation_events.txt
+++ b/AncientReligions/events/celtic_reincarnation_events.txt
@@ -1,0 +1,273 @@
+#######################################
+#
+# ANCIENT RELIGIONS
+# - Celtic Reincarnation
+#
+# Event ID  ancrel.0270 - ancrel.0280 reserved
+#
+#######################################
+
+# [on_birth] Child might be a reincarnation
+# Duplicate event RoI.10000 for the religion check and to have Celtic specific text on chained event
+character_event = {
+	id = ancrel.0270
+	hide_window = yes
+	
+	is_triggered_only = yes
+	
+	only_men = yes
+	
+	trigger = {
+		has_dlc = "Rajas of India"
+		OR = {
+			religion = druidic
+			religion = druidic_reformed
+		}
+		OR = {
+			father = {
+				ai = no
+				is_reincarnated = no
+				father_even_if_dead = {
+					OR = {
+						is_alive = no
+						father_even_if_dead = {
+							is_alive = no
+						}
+					}
+				}
+				NOT = {
+					any_sibling = {
+						is_reincarnated = yes
+					}
+				}
+			}
+			mother = {
+				ai = no
+				is_reincarnated = no
+				father_even_if_dead = {
+					OR = {
+						is_alive = no
+						father_even_if_dead = {
+							is_alive = no
+						}
+					}
+				}
+				NOT = {
+					any_sibling = {
+						is_reincarnated = yes
+					}
+				}
+			}
+		}
+		NOT = {
+			any_sibling = {
+				is_reincarnated = yes
+			}
+		}
+	}
+	
+	option = {
+		name = OK
+		if = {
+			limit = {
+				father = { 
+					ai = no
+				}
+			}
+			if = {
+				limit = {
+					father = {
+						father_even_if_dead = {
+							father_even_if_dead = {
+								is_alive = no
+							}
+						}
+					}
+				}
+				father = {
+					father_even_if_dead = {
+						father_even_if_dead = {
+							ROOT = {
+								set_reincarnation = THIS
+							}
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					is_reincarnated = no
+				}
+				father = {
+					father_even_if_dead = {
+						ROOT = {
+							set_reincarnation = THIS
+						}
+					}
+				}
+			}
+			
+			father = {
+				character_event = {
+					id = ancrel.0271
+					days = 3
+				}
+			}
+		}
+		if = {
+			limit = {
+				mother = { ai = no }
+				is_reincarnated = no
+			}
+			if = {
+				limit = {
+					mother = {
+						father_even_if_dead = {
+							father_even_if_dead = {
+								is_alive = no
+							}
+						}
+					}
+				}
+				mother = {
+					father_even_if_dead = {
+						father_even_if_dead = {
+							ROOT = {
+								set_reincarnation = THIS
+							}
+						}
+					}
+				}
+			}
+			if = {
+				limit = {
+					is_reincarnated = no
+				}
+				mother = {
+					father_even_if_dead = {
+						ROOT = {
+							set_reincarnation = THIS
+						}
+					}
+				}
+			}
+			
+			mother = {
+				character_event = {
+					id = ancrel.0271
+					days = 3
+				}
+			}
+		}
+	}
+}
+
+# Reincarnation: Player notices the similarities
+character_event = {
+	id = ancrel.0271
+	desc = EVTDESCancrel.0271
+	picture = GFX_evt_reincarnation
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTAancrel.0271 # Yes, clearly
+		
+		hidden_tooltip = {
+			FROM = {
+				add_trait = reincarnation
+				character_event = {
+					id = RoI.10002 # Back to RoI event chain, which is not Indian specific.
+					days = 912
+				}
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTBancrel.0271 # Nonsense!
+		
+		hidden_tooltip = {
+			FROM = {
+				set_reincarnation = 0
+			}
+		}
+	}
+}
+
+# [on_yearly_childhood_pulse] Reincarnation: Youth picks up a personality trait from the previous life
+# Duplicate event RoI.10010 for the religion check
+character_event = {
+	id = ancrel.0272
+	desc = EVTDESC_RoI_10010
+	picture = GFX_evt_reincarnation
+	border = GFX_event_normal_frame_religion
+	
+	is_triggered_only = yes
+	
+	trigger = {
+		OR = {
+			religion = druidic
+			religion = druidic_reformed
+		}
+		has_dlc = "Rajas of India"
+		has_character_flag = reincarnation_education
+		NOT = { personality_traits = 5 }
+		reincarnation_scope = {
+			ROOT = {
+				can_copy_personality_trait_from = PREV
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTA_RoI_10010
+		reincarnation_scope = {
+			ROOT = {
+				copy_random_personality_trait = PREV
+			}
+		}
+		hidden_tooltip = {
+			if = {
+				limit = {
+					father = {
+						ai = no
+					}
+				}
+				father = {
+					character_event = {
+						id = RoI.10011
+						days = 2
+					}
+				}
+			}
+			if = {
+				limit = {
+					mother = {
+						ai = no
+					}
+				}
+				mother = {
+					character_event = {
+						id = RoI.10011
+						days = 2
+					}
+				}
+			}
+			if = {
+				limit = {
+					guardian = {
+						ai = no
+					}
+				}
+				guardian = {
+					character_event = {
+						id = RoI.10011
+						days = 2
+					}
+				}
+			}
+		}
+	}
+}

--- a/AncientReligions/events/celtic_sacred_symbols.txt
+++ b/AncientReligions/events/celtic_sacred_symbols.txt
@@ -69,6 +69,12 @@ province_event = {
 			factor = 0.02
 		}
 		modifier = {
+			owner = {
+				trait = bad_druid
+			}
+			factor = 50
+		}
+		modifier = {
 			factor = 1.2
 			owner = {
 				trait = cynical

--- a/AncientReligions/events/druidic_caste_events.txt
+++ b/AncientReligions/events/druidic_caste_events.txt
@@ -3,7 +3,7 @@
 # ANCIENT RELIGIONS
 # - Druidic Caste Events
 #
-# Event ID ancrel.0152 - ancrel.0207, ancrel.0211, ancrel.0212 reserved
+# Event ID ancrel.0152 - ancrel.0207, ancrel.0211, ancrel.0212, ancrel.0260, ancrel.0261 reserved
 #
 #######################################
 
@@ -332,7 +332,17 @@ character_event = {
 	is_triggered_only = yes
 	
 	option = {
-		name = EVTOPTAancrel.0246
+		name = EVTOPTAancrel.0246 # Send for a master of law
+		hidden_tooltip = {
+			character_event = {
+				id = ancrel.0245 
+				days = 1
+			}
+		}
+	}
+	
+	option = {
+		name = EVTOPTBancrel.0246 # Send for a servant of god
 		hidden_tooltip = {
 			character_event = {
 				id = ancrel.0152
@@ -340,19 +350,9 @@ character_event = {
 			}
 		}
 	}
-	
-	option = {
-		name = EVTOPTBancrel.0246
-		hidden_tooltip = {
-			character_event = {
-				id = ancrel.0245
-				days = 1
-			}
-		}
-	}
 }
 
-# Liege doesn't have a Druid - fired on a yearly basis to remind players
+#[on_yearly_pulse] Liege doesn't have a Druid - fired on a yearly basis to remind players
 character_event = {
 	id = ancrel.0153
 	desc = EVTDESCancrel.0153
@@ -365,15 +365,10 @@ character_event = {
 	trigger = {
 		ai = no
 		OR = {
-				religion = druidic
-				religion = druidic_reformed
+			religion = druidic
+			religion = druidic_reformed
 		}
 		primary_title = { higher_tier_than = BARON }
-		NOT = {
-			any_vassal = {
-				has_minor_title = title_court_druid
-			}
-		}
 		NOT = {
 			any_courtier = {
 				has_minor_title = title_court_druid
@@ -382,7 +377,129 @@ character_event = {
 	}
 	
 	option = {
+		name = EVTOPTBancrel.0153
+		trigger = {
+			any_courtier = {
+				trait = druid
+				is_adult = yes
+				OR = {
+					religion = druidic
+					religion = druidic_reformed
+				}
+			}
+		}
+		random_courtier = {
+			limit = { 
+				trait = druid 
+				is_adult = yes
+				is_ruler = no # Councillor landed vassals are courtier
+				OR = {
+					religion = druidic
+					religion = druidic_reformed
+				}
+			}
+			give_minor_title = title_court_druid
+		}
+	}
+
+	option = {
 		name = EVTOPTAancrel.0153 #Ok
+	}
+}
+
+# Druidic priest get the druid trait as well
+character_event = {
+	id = ancrel.0260
+	hide_window = yes
+	
+	trigger = {
+		is_ruler = yes
+		is_priest = yes
+		OR = {
+			religion = druidic
+			religion = druidic_reformed
+		}
+		NOT = { trait = druid }
+		NOT = { trait = bad_druid }
+	}
+	
+	mean_time_to_happen = {
+		days = 1
+	}
+	
+	immediate = {
+		add_trait = druid	
+	}
+	
+	option = {
+		name = OK
+	}
+}
+
+# Druid can become known as wicked, if he can't hide his sins
+character_event = {
+	id = ancrel.0261
+	desc = EVTDESCancrel.0261
+	picture = GFX_evt_druid
+	
+	trigger = {
+		has_dlc = "Sons of Abraham"
+		OR = {
+			religion = druidic
+			religion = druidic_reformed
+		}
+		trait = druid
+		NOT = { trait = bad_druid }
+		NOT = { trait = incapable }
+		NOT = { intrigue = 3 }
+		NOT = { diplomacy = 5 } # 5 instead of 3 (vanilla) to compensate from druid trait +2 bonus
+		OR = {
+			trait = deceitful 
+			trait = cruel
+			trait = arbitrary 
+			trait = envious
+			trait = craven
+			trait = slothful
+			trait = shy
+			trait = paranoid
+			trait = lunatic
+			trait = possessed
+		}
+	}
+
+	mean_time_to_happen = {
+		months = 24
+	}
+	
+	option = {
+		name = EVTOPTAancrel.0261
+		add_trait = bad_druid
+		remove_trait = druid
+		if = {
+			limit = {
+				is_ruler = yes
+				has_nickname = no
+				NOT = { trait = possessed }
+				NOT = { trait = lunatic }
+			}
+			give_nickname = nick_the_wicked
+		}
+		if = {
+			limit = {
+				is_ruler = yes
+				has_nickname = no
+				trait = possessed
+			}
+			give_nickname = nick_the_bewitched
+		}
+		if = {
+			limit = {
+				is_ruler = yes
+				has_nickname = no
+				trait = lunatic
+			}
+			give_nickname = nick_the_mad
+		}
 	}
 }
 
@@ -398,9 +515,13 @@ character_event = {
 	option = {
 		name = "EVTOPTAancrel.0183" # Send him on the path of the warrior
 		
-		FROM = { prestige = 20}
-		FROM = { change_martial = 1}
-		FROM = { change_learning = -1}
+		custom_tooltip = {
+			text = path_of_the_warriors
+		
+			FROM = { prestige = 20}
+			FROM = { change_martial = 1}
+			FROM = { change_learning = -1}
+		}
 	}
 
 	option = {
@@ -429,7 +550,7 @@ character_event = {
 			FROM = { change_martial = -1}
 			hidden_tooltip = {
 				FROM = {
-					character_event = {
+					narrative_event = {
 						id = ancrel.0185
 						days = 3
 					}
@@ -618,7 +739,7 @@ character_event = {
 		hidden_tooltip = {
 			FROM = { 
 				character_event = { id = ancrel.0118 days = 1460 }
-				character_event = { id = ancrel.0185 days = 3 }
+				narrative_event = { id = ancrel.0185 days = 3 }
 			}
 		}
 		piety = 100
@@ -1347,6 +1468,7 @@ character_event = {
 }
 
 # Remove druidic traits on conversion
+# Note: using religious = yes is not suitable as it also removes the trait on reformation
 character_event = {
 	id = ancrel.0247
 	hide_window = yes
@@ -1362,8 +1484,11 @@ character_event = {
 			trait = head1
 			trait = head2
 			trait = druid
+			trait = bad_druid
 			trait = fian
 			trait = changeling
+			trait = learning_druidic_arts
+			trait = celtic_knight
 		}
 	}
 	
@@ -1375,8 +1500,11 @@ character_event = {
 		remove_trait = head1
 		remove_trait = head2
 		remove_trait = druid
+		remove_trait = bad_druid
 		remove_trait = fian
 		remove_trait = changeling
+		remove_trait = learning_druidic_arts
+		remove_trait = celtic_knight
 	}
 	
 	option = {

--- a/AncientReligions/events/druidic_rebirth_events.txt
+++ b/AncientReligions/events/druidic_rebirth_events.txt
@@ -85,6 +85,12 @@ character_event = {
 		custom_tooltip = {
 			text = adopt_celtic_rites
 			piety = -50
+			if = {
+				limit = {
+					NOT = { religion_group = pagan_group }
+				}
+				add_trait = sympathy_pagans
+			}
 			add_character_modifier = {
 				name = celtic_ways
 				duration = -1
@@ -111,6 +117,7 @@ character_event = {
 						prisoner = no
 						war = no
 						NOT = { trait = incapable }
+						is_ruler = no # Councillors can be both courtier and vassals
 					}
 					character_event = { id = ancrel.0003 days = 5 }
 				}
@@ -136,19 +143,26 @@ character_event = {
 	}
 	
 	mean_time_to_happen = {
-		months = 12
+		months = 24
 	}
 	
 	option = {
 		name = EVTOPTAancrel.0002
 		ai_chance = { factor = 50 }
 		hidden_tooltip = { remove_character_modifier = celtic_ways }
+		if = {
+			limit = {
+				religion_group = christian
+			}
+			add_trait = sympathy_christendom
+		}
 		religion = druidic
 		piety = 50
 	}
 	option = {
 		name = EVTOPTBancrel.0002
 		piety = 50
+		remove_trait = sympathy_pagans
 		ai_chance = { factor = 50 }
 		religion_head = {
 			opinion = {
@@ -184,6 +198,12 @@ character_event = {
 		custom_tooltip = {
 			text = adopt_celtic_rites
 			piety = -50
+			if = {
+				limit = {
+					NOT = { religion_group = pagan_group }
+				}
+				add_trait = sympathy_pagans
+			}
 			add_character_modifier = {
 				name = celtic_ways
 				duration = -1

--- a/AncientReligions/events/fianna_events.txt
+++ b/AncientReligions/events/fianna_events.txt
@@ -891,7 +891,7 @@ character_event = {
 	}
 }
 
-# Fianna Reforms
+#[on_reform_religion] Fianna Reforms
 character_event = {
 	id = ancrel.0009
 	hide_window = yes

--- a/AncientReligions/events/hellenic_vestales_events.txt
+++ b/AncientReligions/events/hellenic_vestales_events.txt
@@ -114,7 +114,7 @@ character_event = {
 	}
 }
 
-# Cleanup when a Vestalis dies
+#[on_death] Cleanup when a Vestalis dies
 character_event = {
 	id = ancrel.2123
 	hide_window = yes

--- a/AncientReligions/interface/druidic.gfx
+++ b/AncientReligions/interface/druidic.gfx
@@ -22,7 +22,7 @@ spriteTypes = {
 		effectFile = "gfx/FX/buttonstate.lua"
 	}
 	spriteType = {
-		name = "GFX_trait_bad_priest_druidic"
+		name = "GFX_trait_bad_druid"
 		texturefile = "gfx/traits/bad_priest_druid.dds"
 		noOfFrames = 1
 		norefcount = yes

--- a/AncientReligions/localisation/Druidic_Caste_Events.csv
+++ b/AncientReligions/localisation/Druidic_Caste_Events.csv
@@ -5,6 +5,8 @@ invite_druid_to_court;Invite Druid to Court;French;German;;Spanish;;;;;;;;;;;x
 invite_druid_to_court_desc;Invite a Druid to your court - this can only be done every two years;French;German;;Spanish;;;;;;;;;;;x
 druid;Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 druid_desc;The Druid's knowledge of the ancient Celtic ballads and of sacred traditions is great and their power among the Celts is without equal. They are responsible for organising worship and sacrifices, divination, and judicial procedure in Celtic society.;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+bad_druid;Wicked Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
+bad_druid_desc;The personality and habits of this druid are very inappropriate for his position. And what's worse, he has been unable to hide them from public view.;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
 EVTDESCancrel.0152;I have searched far and wide for a worthy Druid to serve at my court. He will organise worship and sacrifices, divination, and judicial procedure, encourage my warriors, and provide me counsel. At long last, one such man has arrived at my court, but I am not sure whether he is worthy... A ruler must choose his Druid wisely, after all.;French;German;;Spanish;;;;;;;;;;;x
 EVTOPTAancrel.0152;Let us meet, then.;French;German;;Spanish;;;;;;;;;;;x
 EVTDESCancrel.0245;I have searched far and wide for a worthy Druid to serve at my court. He will organise worship and sacrifices, divination, and judicial procedure, encourage my warriors, and provide me counsel. At long last, one such man has arrived at my court, but I am not sure whether he is worthy... A ruler must choose his Druid wisely, after all.;French;German;;Spanish;;;;;;;;;;;x
@@ -14,8 +16,7 @@ EVTOPTAancrel.0246;Send for a master of law.;French;German;;Spanish;;;;;;;;;;;x
 EVTOPTBancrel.0246;Bring me a servant of the gods.;French;German;;Spanish;;;;;;;;;;;x
 EVTDESCancrel.0153;The people of your court are incredulous. “Great [Root.GetTitle], it is a shame that you do not have a Druid at court! Are you to be like a Bard without his voice, a warrior without his spear, a farmer without his seeds?” No self-respecting ruler of the islands can go without a Druid, after all.;French;German;;Spanish;;;;;;;;;;;x
 EVTOPTAancrel.0153;I must find a knowledgeable Druid soon, and fast!;French;German;;Spanish;;;;;;;;;;;x
-EVTOPTBancrel.0153;I will give the title to one of my courtiers;French;German;;Spanish;;;;;;;;;;;x
-EVTOPTCancrel.0153;I will give the title to one of my vassals;French;German;;Spanish;;;;;;;;;;;x
+EVTOPTBancrel.0153;There seems to be a suitable candidate at my court;French;German;;Spanish;;;;;;;;;;;x
 new_druid_in_court;New Druid in Court;French;German;;Spanish;;;;;;;;;;;x
 new_druid_in_court_desc;A Druid has just arrived in this lord's court.;French;German;;Spanish;;;;;;;;;;;x
 title_court_druid;Court Druid;FRENCH;GERMAN;SPANISH;;;;;;;;;;x
@@ -164,3 +165,5 @@ EVTDESCancrel.0206;Father dies, Player Child is heir;;;;;;;;;;;;;x
 EVTOPTAancrel.0206;Ok;;;;;;;;;;;;;x
 learning_druidic_arts;Novice;French;German;;Spanish;;;;;;;;;;;x
 learning_druidic_arts_desc;This character is learning the secrets arts and rituals of the Druids, he has much to learn;Franch;German;;Spanish;;;;;;;;;;;;x
+EVTDESCancrel.0261;A Druid is expected to follow the Celtic Virtues of honor, loyalty, hospitality, honesty, justice and courage. Gossip is starting to spread about your wicked habits.;FRENCH;GERMAN;;SPANISH;;;;;;;;;;;;;;x
+EVTOPTAancrel.0261;May [Root.Religion.GetRandomGodName] have mercy on me.;FRENCH;GERMAN;;SPANISH;;;;;;;;;;;;;;x

--- a/AncientReligions/localisation/celtic_reincarnation_events.csv
+++ b/AncientReligions/localisation/celtic_reincarnation_events.csv
@@ -1,0 +1,5 @@
+#CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
+;;;;;;;;;;
+EVTDESCancrel.0271;After mourning the death of the person in the Otherworld which made this new birth possible, you notice your little [GetFromRelation] [From.GetFirstName] has an odd birthmark that closely matches that of my [GetFromReincarnationRelation], [From.Reincarnation.GetBestName]. Could [From.Reincarnation.GetSubjectPronoun] have been reborn as my [GetFromRelation] in this life ?;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
+EVTOPTAancrel.0271;Yes, clearly this is a sign of the Gods;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
+EVTOPTBancrel.0271;No, this is merely a coincidence;FRENCH;GERMAN;;SPANISH;;;;;;;;;x


### PR DESCRIPTION
Hi Superpat, 

Here are some small suggestions to improve the Celtic mechanics. 
I've tested all, except the reincarnation: event doesn't trigger from console, not sure why...
I can adapt and/or drop some of the changes based on your review.

1- Druidic temple holders also get the druid trait on nomination: seems more logical as they are called Druids after all ^^
2- Court druid has to be courtier (not a vassal):  it's consequence of 1, otherwise it would be too easy with all the druid religious vassal.
3- Reminder for no court druid with auto-suggest: enable the yearly reminder of no court druid, with an auto-suggest in case of a suitable candidate is present in court.
4- Wicked druid trait: opposite to druid trait, similar to SoA bad priest traits.
5- Sympathy traits: restoring the old Celtic rites gives trait sympathy for pagans, and converting gives sympathy for christians. Makes the restoration/conversion process more smooth as vassals may switch at different pace, and a bit less pressure on 1st converted ruler.
6- Reincarnation events: based on RoI event chain.
